### PR TITLE
fix(tags): order tags when they are multiple per category

### DIFF
--- a/internal/load/datacenter.go
+++ b/internal/load/datacenter.go
@@ -4,11 +4,11 @@
 package load
 
 import (
-	"github.com/newrelic/nri-vsphere/internal/performance"
-
+	"sort"
 	"sync"
 
 	"github.com/newrelic/nri-vsphere/internal/events"
+	"github.com/newrelic/nri-vsphere/internal/performance"
 
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -129,6 +129,9 @@ func (dc *Datacenter) GetPerfMetrics(ref mor) []performance.PerfMetric {
 func (dc *Datacenter) GetTagsByCategories(ref mor) map[string]string {
 	tagsByCategory := make(map[string]string)
 	if tags, ok := dc.Tags[ref]; ok {
+		sort.Slice(tags, func(i, j int) bool {
+			return tags[i].Name < tags[j].Name
+		})
 		for _, t := range tags {
 			if _, ok := tagsByCategory[t.Category]; ok {
 				tagsByCategory[t.Category] = tagsByCategory[t.Category] + "|" + t.Name

--- a/internal/load/datacenter_test.go
+++ b/internal/load/datacenter_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package load
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatacenter_GetTagsByCategories(t *testing.T) {
+	ref := mor{Type: "type", Value: "val"}
+	tags := []Tag{
+		{
+			Name:     "A",
+			Category: "cat1",
+		},
+		{
+			Name:     "B",
+			Category: "cat1",
+		},
+		{
+			Name:     "B",
+			Category: "cat2",
+		},
+		{
+			Name:     "A",
+			Category: "cat2",
+		},
+	}
+	tagsByObject := make(map[mor][]Tag)
+	tagsByObject[ref] = tags
+	dc := NewDatacenter(nil)
+	dc.AddTags(tagsByObject)
+
+	tbc := dc.GetTagsByCategories(ref)
+	assert.Equal(t, "A|B", tbc["cat1"], "Tags should should be ordered")
+	assert.Equal(t, "A|B", tbc["cat2"], "Tags should should be ordered")
+}


### PR DESCRIPTION
* Orders tags by name so they don't change when multiple tags per category like `tagA|TagB`
* Add test