### PR TITLE
feat: use infra sdk storage for timestamp cache

### DIFF
--- a/cmd/nri-vsphere/nri-vsphere.go
+++ b/cmd/nri-vsphere/nri-vsphere.go
@@ -6,8 +6,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -89,21 +87,6 @@ func checkAndSanitizeConfig(config *load.Config) {
 		config.Logrus.Fatal("missing argument `pass`, please check if password has been supplied")
 	}
 
-	if config.Args.EnableVsphereEvents {
-		if config.Args.AppDataDir == "" && runtime.GOOS == "windows" {
-			config.Logrus.Fatal("missing argument `app_data_dir`, in newer version of the Agent it is injected automatically, please update or specify argument in integration config file")
-		}
-
-		if config.Args.AgentDir == "" && runtime.GOOS != "windows" {
-			config.Logrus.Fatal("missing argument `agent_dir`, in newer version of the Agent it is injected automatically, please update or specify argument in integration config file")
-		}
-		if runtime.GOOS == "windows" {
-			config.CachePath = filepath.Join(config.Args.AppDataDir, "/data/integration/events-cache")
-		} else {
-			//to test locally in darwin systems you can pass as argument agetn_dir=./ and create te folder "data/integration/events-cache"
-			config.CachePath = filepath.Join(config.Args.AgentDir, "/data/integration/events-cache")
-		}
-	}
 	config.Args.DatacenterLocation = strings.ToLower(config.Args.DatacenterLocation)
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -34,6 +34,5 @@ func (c *Cache) ReadTimestampCache() (time.Time, error) {
 
 func (c *Cache) WriteTimestampCache(lastTimestamp time.Time) error {
 	c.store.Set(c.resourceName, lastTimestamp.UnixNano())
-	err := c.store.Save()
-	return err
+	return c.store.Save()
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,18 +1,14 @@
 package cache
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path"
+	"github.com/newrelic/infra-integrations-sdk/persist"
 	"time"
 )
 
 type Cache struct {
-	LastTimestamp string `json:"lastTimestamp"`
-	resourceName  string
-	cachePath     string
+	resourceName string
+	store        persist.Storer
 }
 
 type CacheInterface interface {
@@ -20,60 +16,24 @@ type CacheInterface interface {
 	WriteTimestampCache(lastTimestamp time.Time) error
 }
 
-func NewCache(resourceName string, cachePath string) *Cache {
+func NewCache(resourceName string, store persist.Storer) *Cache {
 	return &Cache{
 		resourceName: resourceName,
-		cachePath:    cachePath,
+		store:        store,
 	}
 }
 
 func (c *Cache) ReadTimestampCache() (time.Time, error) {
-	filePath := path.Join(c.cachePath, getName(c.resourceName))
-
-	jsonFile, err := os.Open(filePath)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("error while opening cache file: %s, ", err.Error())
-	}
-	defer jsonFile.Close()
-
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	var ts int64
+	_, err := c.store.Get(c.resourceName, &ts)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("error while reading cache file: %s, ", err.Error())
 	}
-	var tmpC Cache
-	err = json.Unmarshal(byteValue, &tmpC)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("error while unmashalling cache file content: %s, ", err.Error())
-	}
-	c.LastTimestamp = tmpC.LastTimestamp
-
-	timestamp, err := time.Parse(time.RFC1123, c.LastTimestamp)
-	return timestamp, err
+	return time.Unix(0, ts), err
 }
 
 func (c *Cache) WriteTimestampCache(lastTimestamp time.Time) error {
-	filePath := path.Join(c.cachePath, getName(c.resourceName))
-
-	err := os.Mkdir(c.cachePath, 0755)
-	if err != nil && !os.IsExist(err) {
-		return fmt.Errorf("error whilecreating directory: %s, %s ", err.Error(), c.cachePath)
-	}
-
-	jsonFile, err := os.OpenFile(filePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer jsonFile.Close()
-
-	c.LastTimestamp = lastTimestamp.Format(time.RFC1123)
-	s, err := json.Marshal(c)
-	if err != nil {
-		return err
-	}
-	_, err = jsonFile.WriteAt(s, 0)
+	c.store.Set(c.resourceName, lastTimestamp.UnixNano())
+	err := c.store.Save()
 	return err
-}
-
-func getName(resource string) string {
-	return "vsphere-" + resource + ".json"
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/newrelic/infra-integrations-sdk/persist"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Cache_SavesCorrectTimestamp(t *testing.T) {
+
+	datacenter := "my-datacenter"
+	store := persist.NewInMemoryStore()
+
+	//given
+	expected := time.Now()
+	c := NewCache(datacenter, store)
+	assert.NotNil(t, c)
+
+	//when
+	err := c.WriteTimestampCache(expected)
+	assert.NoError(t, err)
+
+	//then
+	actual, err := c.ReadTimestampCache()
+	assert.NoError(t, err)
+
+	assert.True(t, expected.Equal(actual))
+	assert.Equal(t, expected.UnixNano(), actual.UnixNano())
+}

--- a/internal/collect/datacenters.go
+++ b/internal/collect/datacenters.go
@@ -5,13 +5,14 @@ package collect
 
 import (
 	"context"
+	"time"
+
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/newrelic/nri-vsphere/internal/cache"
 	"github.com/newrelic/nri-vsphere/internal/events"
 	"github.com/newrelic/nri-vsphere/internal/load"
 	"github.com/newrelic/nri-vsphere/internal/performance"
 	"github.com/vmware/govmomi/vim25/mo"
-	"time"
 )
 
 // Datacenters VMWare
@@ -84,5 +85,8 @@ func newCacheStore(config *load.Config) (persist.Storer, error) {
 	// we have to set a distinct default path otherwise it gets overwritten by the default Infra SDK store
 	path := persist.DefaultPath(config.IntegrationName + "_timestamps")
 	store, err := persist.NewFileStore(path, config.Logrus, time.Hour*24)
+	if err != nil {
+		store = persist.NewInMemoryStore()
+	}
 	return store, err
 }

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -29,8 +29,6 @@ type ArgumentList struct {
 
 	EnableVsphereEvents bool   `default:"false" help:"If set the integration will collect as well vSphere events at datacenter level"`
 	EventsPageSize      string `default:"100" help:"Number of events fetched from the vCenter for each page"`
-	AgentDir            string `default:"" help:"Agent Directory, injected by agent to save cache in Linux environments, es: /var/db/newrelic-infra" os:"linux"`
-	AppDataDir          string `default:"" help:"Agent Data Directory, injected by agent to save cache in Windows environments, es: %PROGRAMDATA%\\New Relic\\newrelic-infra" os:"windows"`
 
 	EnableVspherePerfMetrics bool   `default:"false" help:"If set the integration will collect as well vSphere performance metrics"`
 	PerfLevel                int    `default:"1" help:"Performance counter level that will be collected"`
@@ -46,9 +44,8 @@ type ArgumentList struct {
 
 	EnableVsphereTags      bool `default:"false" help:"If true tags will be collected. Tags are available when connecting to vcenter"`
 	EnableVsphereSnapshots bool `default:"false" help:"If set to true integration will collect, process and send as well data regarding vm Snapshots"`
-
-	ValidateSSL bool `default:"false" help:"Validate SSL"`
-	Version     bool `default:"false" help:"If set prints version and exit"`
+	ValidateSSL            bool   `default:"false" help:"Validate SSL"`
+	Version                bool   `default:"false" help:"If set prints version and exit"`
 }
 
 type Config struct {


### PR DESCRIPTION
Infra SDK already has a storage feature that we can leverage to store temporary data. This reduces our need for custom code to "cache" the last timestamp