### PR TITLE
feat(performance): add datastore/cluster/resource performance metrics

### DIFF
--- a/config/vsphere-performance.metrics
+++ b/config/vsphere-performance.metrics
@@ -3,8 +3,13 @@
 # vary depending on the vCenter version and configuration.
 # As a best practice, only metrics that are needed should be collected since the number of metrics
 # and their level affects the vCenter performance. 
+
+# host and vm metrics are available in intervals of 20 seconds (Real time), and resourcePool, cluster and datastore 
+# performance metrics are available in intervals of 300 seconds(historical metrics).
+
 # For more information regarding performance metrics, please check out the official vmWare documentation:
 # https://docs.vmware.com/en/VMware-vSphere/6.7/vsphere-esxi-vcenter-server-67-monitoring-performance-guide.pdf
+# https://vdc-repo.vmware.com/vmwb-repository/dcr-public/790263bc-bd30-48f1-af12-ed36055d718b/e5f17bfc-ecba-40bf-a04f-376bbb11e811/vim.PerformanceManager.html
 
 host:
   level_1:
@@ -235,6 +240,60 @@ vm:
     - sys.heartbeat.latest
     - sys.osUptime.latest
 
+resourcePool:
+  level_1:
+    - cpu.usagemhz.average
+    - mem.consumed.average
+    - mem.overhead.average
+    - mem.vmmemctl.average
+  level_2:
+    - cpu.cpuentitlement.latest
+    - mem.active.average
+    - mem.compressed.average
+    - mem.compressionRate.average
+    - mem.decompressionRate.average
+    - mem.granted.average
+    - mem.mementitlement.latest
+    - mem.shared.average
+    - mem.swapped.average
+    - mem.zero.average
+    - power.power.average
+  level_3:
+    - power.energy.summation
+  level_4:
+    - cpu.capacity.contention.average
+    - cpu.capacity.demand.average
+    - cpu.capacity.entitlement.average
+    - cpu.capacity.usage.average
+    - cpu.corecount.contention.average
+    - cpu.corecount.provisioned.average
+    - cpu.usagemhz.maximum
+    - cpu.usagemhz.minimum
+    - disk.throughput.contention.average
+    - disk.throughput.usage.average
+    - mem.active.maximum
+    - mem.active.minimum
+    - mem.capacity.contention.average
+    - mem.capacity.entitlement.average
+    - mem.capacity.provisioned.average
+    - mem.capacity.usage.average
+    - mem.consumed.maximum
+    - mem.consumed.minimum
+    - mem.granted.maximum
+    - mem.granted.minimum
+    - mem.overhead.maximum
+    - mem.overhead.minimum
+    - mem.shared.maximum
+    - mem.shared.minimum
+    - mem.swapped.maximum
+    - mem.swapped.minimum
+    - mem.vmmemctl.maximum
+    - mem.vmmemctl.minimum
+    - mem.zero.maximum
+    - mem.zero.minimum
+    - net.throughput.contention.summation
+    - net.throughput.usage.average
+
 clusterComputeResource:
   level_1:
     - cpu.usage.average
@@ -319,3 +378,22 @@ clusterComputeResource:
     - net.throughput.provisioned.average
     - net.throughput.usable.average
     - net.throughput.usage.average
+
+datastore:
+  level_1:
+    - datastore.numberReadAveraged.average
+    - datastore.numberWriteAveraged.average
+    - disk.capacity.latest
+    - disk.provisioned.latest
+    - disk.unshared.latest
+    - disk.used.latest
+  level_2:
+    - datastore.read.average
+    - datastore.write.average
+  level_3:
+  level_4:
+    - datastore.throughput.contention.average
+    - datastore.throughput.usage.average
+    - disk.capacity.contention.average
+    - disk.capacity.provisioned.average
+    - disk.capacity.usage.average

--- a/internal/collect/clusters.go
+++ b/internal/collect/clusters.go
@@ -5,6 +5,8 @@ package collect
 
 import (
 	"context"
+
+	"github.com/newrelic/nri-vsphere/internal/performance"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/newrelic/nri-vsphere/internal/load"
@@ -45,7 +47,7 @@ func Clusters(config *load.Config) {
 		}
 
 		if config.Args.EnableVspherePerfMetrics && dc.PerfCollector != nil {
-			collectedData := dc.PerfCollector.Collect(refSlice, dc.PerfCollector.MetricDefinition.ClusterComputeResource)
+			collectedData := dc.PerfCollector.Collect(refSlice, dc.PerfCollector.MetricDefinition.ClusterComputeResource, performance.FiveMinutesInterval)
 			dc.AddPerfMetrics(collectedData)
 		}
 

--- a/internal/collect/hosts.go
+++ b/internal/collect/hosts.go
@@ -5,6 +5,8 @@ package collect
 
 import (
 	"context"
+
+	"github.com/newrelic/nri-vsphere/internal/performance"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/newrelic/nri-vsphere/internal/load"
@@ -48,7 +50,7 @@ func Hosts(config *load.Config) {
 		}
 
 		if config.Args.EnableVspherePerfMetrics && dc.PerfCollector != nil {
-			collectedData := dc.PerfCollector.Collect(refSlice, dc.PerfCollector.MetricDefinition.Host)
+			collectedData := dc.PerfCollector.Collect(refSlice, dc.PerfCollector.MetricDefinition.Host, performance.RealTimeInterval)
 			dc.AddPerfMetrics(collectedData)
 		}
 	}

--- a/internal/collect/vms.go
+++ b/internal/collect/vms.go
@@ -5,8 +5,10 @@ package collect
 
 import (
 	"context"
-	"github.com/vmware/govmomi/vim25/types"
 	"time"
+
+	"github.com/newrelic/nri-vsphere/internal/performance"
+	"github.com/vmware/govmomi/vim25/types"
 
 	"github.com/newrelic/nri-vsphere/internal/load"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -56,7 +58,7 @@ func VirtualMachines(config *load.Config) {
 		}
 
 		if config.Args.EnableVspherePerfMetrics && dc.PerfCollector != nil {
-			collectedData := dc.PerfCollector.Collect(refSlice, dc.PerfCollector.MetricDefinition.VM)
+			collectedData := dc.PerfCollector.Collect(refSlice, dc.PerfCollector.MetricDefinition.VM, performance.RealTimeInterval)
 			dc.AddPerfMetrics(collectedData)
 		}
 		config.Logrus.WithField("seconds", time.Since(load.Now).Seconds()).Debug("vm perf metrics collected")

--- a/internal/performance/performance.go
+++ b/internal/performance/performance.go
@@ -141,10 +141,13 @@ func (c *PerfCollector) processEntityMetrics(metricsValues *types.PerfEntityMetr
 			continue
 		}
 		var metricVal int64
-		for _, val := range metricValueSeries.Value {
-			metricVal += val
+		if len(metricValueSeries.Value) < 1 {
+			c.logger.Debugf("The metric: %v is not containing at least one sample, this is not expected", name)
+			continue
 		}
-
+		// MaxSamples is set to 1 but the API is retreiving multiple samples with the same value for historical interval metrics.
+		// We will take just first one.
+		metricVal = metricValueSeries.Value[0]
 		perfMetricsByRef[metricsValues.Entity] = append(perfMetricsByRef[metricsValues.Entity], PerfMetric{
 			Counter: name,
 			Value:   metricVal,

--- a/internal/performance/performance.go
+++ b/internal/performance/performance.go
@@ -21,6 +21,9 @@ import (
 
 const (
 	counterLimit = 150 // limits the number of perf metrics to be added to avoid reach the 256 limit per event
+
+	RealTimeInterval    = 20
+	FiveMinutesInterval = 300
 )
 
 type PerfCollector struct {
@@ -75,7 +78,7 @@ func NewPerfCollector(client *govmomi.Client, logger *logrus.Logger, perfMetricF
 	return perfCollector, err
 }
 
-func (c *PerfCollector) Collect(mos []types.ManagedObjectReference, metrics []types.PerfMetricId) map[types.ManagedObjectReference][]PerfMetric {
+func (c *PerfCollector) Collect(mos []types.ManagedObjectReference, metrics []types.PerfMetricId, intervalId int32) map[types.ManagedObjectReference][]PerfMetric {
 	ctx := context.Background()
 	perfMetricsByRef := map[types.ManagedObjectReference][]PerfMetric{}
 
@@ -89,18 +92,19 @@ func (c *PerfCollector) Collect(mos []types.ManagedObjectReference, metrics []ty
 			chunkEntities := mos[i:min(i+c.batchSizePerfEntities, len(mos))]
 			chunkMetrics := metrics[m:min(m+c.batchSizePerfMetrics, len(metrics))]
 
-			for _, vm := range chunkEntities {
+			for _, ref := range chunkEntities {
 				querySpec := types.PerfQuerySpec{
-					Entity:     vm.Reference(),
+					Entity:     ref.Reference(),
 					MaxSample:  1,
 					MetricId:   chunkMetrics,
-					IntervalId: 20,
+					IntervalId: intervalId,
 					//If the optional intervalId is omitted, the metrics are returned in their originally sampled interval.
 					//When an intervalId is specified, the server tries to summarize the information for the specified intervalId.
 					//However, if that interval does not exist or has no data, the server summarizes the information using the best interval available.
 				}
 				query.QuerySpec = append(query.QuerySpec, querySpec)
 			}
+
 			retrievedStats, err := methods.QueryPerf(ctx, c.perfManager.Client(), &query)
 			if err != nil {
 				c.logger.Errorf("failed to exec queryPerf:%s", err)
@@ -136,15 +140,14 @@ func (c *PerfCollector) processEntityMetrics(metricsValues *types.PerfEntityMetr
 			c.logger.Debugf("vCenter returned no samples for the metric: %v", name)
 			continue
 		}
-
-		if len(metricValueSeries.Value) != 1 {
-			c.logger.Debugf("The metric: %v is not containing one sample, this is not expected", name)
-			continue
+		var metricVal int64
+		for _, val := range metricValueSeries.Value {
+			metricVal += val
 		}
 
 		perfMetricsByRef[metricsValues.Entity] = append(perfMetricsByRef[metricsValues.Entity], PerfMetric{
 			Counter: name,
-			Value:   metricValueSeries.Value[0],
+			Value:   metricVal,
 		})
 	}
 }
@@ -193,6 +196,8 @@ func (c *PerfCollector) parseConfigFile(fileName string) error {
 	c.MetricDefinition = &perfMetricsIDs{
 		VM:                     c.buildPerMetricID(cf.VM),
 		ClusterComputeResource: c.buildPerMetricID(cf.ClusterComputeResource),
+		ResourcePool:           c.buildPerMetricID(cf.ResourcePool),
+		Datastore:              c.buildPerMetricID(cf.Datastore),
 		Host:                   c.buildPerMetricID(cf.Host),
 	}
 
@@ -227,14 +232,18 @@ func (c *PerfCollector) buildPerMetricID(countersByLevel map[string][]string) []
 type perfMetricsIDs struct {
 	Host                   []types.PerfMetricId
 	VM                     []types.PerfMetricId
+	ResourcePool           []types.PerfMetricId
 	ClusterComputeResource []types.PerfMetricId
+	Datastore              []types.PerfMetricId
 }
 
 //This struct is used to parse the config file
 type ymlConfig struct {
 	Host                   map[string][]string `yaml:"host"`
 	VM                     map[string][]string `yaml:"vm"`
+	ResourcePool           map[string][]string `yaml:"resourcePool"`
 	ClusterComputeResource map[string][]string `yaml:"clusterComputeResource"`
+	Datastore              map[string][]string `yaml:"datastore"`
 }
 
 func min(a, b int) int {

--- a/internal/performance/performance_test.go
+++ b/internal/performance/performance_test.go
@@ -2,9 +2,14 @@ package performance
 
 import (
 	"context"
+
 	logrus "github.com/sirupsen/Logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"io/ioutil"
+	"os"
+	"testing"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/performance"
@@ -12,9 +17,6 @@ import (
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 func TestPerfCollector_parseConfigFile(t *testing.T) {
@@ -93,7 +95,7 @@ vm:
 
 	ref := types.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-87"}
 
-	metrics := pc.Collect([]types.ManagedObjectReference{ref}, pc.MetricDefinition.VM)
+	metrics := pc.Collect([]types.ManagedObjectReference{ref}, pc.MetricDefinition.VM, RealTimeInterval)
 
 	assert.Equal(t, 1, len(metrics), "we fetched events for 1 vm only")
 	assert.Equal(t, 1, len(metrics[ref]), "we expect only one metric since only metrics with id 2 and 6 are defined for vms and only 2 is map in metricsAvaliableByID")
@@ -130,11 +132,11 @@ func TestPerfMetricsEmptyPerfCollector(t *testing.T) {
 	}
 
 	//no fail SEG/Fault expected
-	metrics := p.Collect(refSlice, nil)
+	metrics := p.Collect(refSlice, nil, RealTimeInterval)
 	assert.Equal(t, map[types.ManagedObjectReference][]PerfMetric{}, metrics)
 
 	ms := []types.PerfMetricId{{CounterId: 1, Instance: ""}, {CounterId: 2, Instance: ""}, {CounterId: 3, Instance: ""}, {CounterId: 4, Instance: ""}}
-	metrics = p.Collect(refSlice, ms)
+	metrics = p.Collect(refSlice, ms, RealTimeInterval)
 	assert.Equal(t, map[types.ManagedObjectReference][]PerfMetric{}, metrics)
 }
 
@@ -182,12 +184,12 @@ func TestPerfMetrics(t *testing.T) {
 	}
 
 	//no fail SEG/Fault expected
-	metrics := p.Collect(refSlice, nil)
+	metrics := p.Collect(refSlice, nil, RealTimeInterval)
 	assert.Equal(t, map[types.ManagedObjectReference][]PerfMetric{}, metrics)
 
 	//Please notice that only value for ID 2 and 6 is defined
 	ms := []types.PerfMetricId{{CounterId: 1, Instance: ""}, {CounterId: 2, Instance: ""}, {CounterId: 5, Instance: ""}, {CounterId: 6, Instance: ""}}
-	metrics = p.Collect(refSlice, ms)
+	metrics = p.Collect(refSlice, ms, RealTimeInterval)
 	assert.Equal(t, map[types.ManagedObjectReference][]PerfMetric{}, metrics)
 
 	p = PerfCollector{
@@ -201,7 +203,7 @@ func TestPerfMetrics(t *testing.T) {
 		batchSizePerfMetrics:   3,
 	}
 
-	metrics = p.Collect(refSlice, ms)
+	metrics = p.Collect(refSlice, ms, RealTimeInterval)
 	assert.Equal(t, len(refSlice), len(metrics), "we have 100 vm, all of them should be present in the map")
 	assert.Equal(t, 1, len(metrics[refSlice[0]]), "we expect only one metric since only metrics with id 2 and 6 are defined for vms and only 2 is map in metricsAvaliableByID")
 

--- a/internal/process/datastores.go
+++ b/internal/process/datastores.go
@@ -60,7 +60,11 @@ func createDatastoreSamples(config *load.Config) {
 				// add tags to inventory due to the inventory workaround
 				checkError(config, e.SetInventoryItem("tags", tagsPrefix+k, v))
 			}
-
+			// Performance metrics
+			perfMetrics := dc.GetPerfMetrics(ds.Self)
+			for _, perfMetric := range perfMetrics {
+				checkError(config, ms.SetMetric(perfMetricPrefix+perfMetric.Counter, perfMetric.Value, metric.GAUGE))
+			}
 		}
 	}
 }

--- a/internal/process/resourcepool.go
+++ b/internal/process/resourcepool.go
@@ -73,7 +73,11 @@ func createResourcePoolSamples(config *load.Config) {
 				// add tags to inventory due to the inventory workaround
 				checkError(config, e.SetInventoryItem("tags", tagsPrefix+k, v))
 			}
-
+			// Performance metrics
+			perfMetrics := dc.GetPerfMetrics(rp.Self)
+			for _, perfMetric := range perfMetrics {
+				checkError(config, ms.SetMetric(perfMetricPrefix+perfMetric.Counter, perfMetric.Value, metric.GAUGE))
+			}
 		}
 	}
 }


### PR DESCRIPTION
* Adds the metrics for the mentioned entities using the historical interval 5min (since they are not available in real time)