### PR TITLE
chore: fix test goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ BINARY_NAME   = nri-$(INTEGRATION)
 GOTOOLS       = github.com/kardianos/govendor  github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml
 
 SNYK_VERSION  = v1.361.3
+SNYK_BIN = snyk-linux
 
 all: build
 build: clean test compile
@@ -41,7 +42,7 @@ compile-windows: deps
 	@GOOS=windows go  build -o $(BIN_DIR)/$(BINARY_NAME).exe ./cmd/...
 
 
-test: deps test-unit test-integration test-security
+test: deps test-unit test-integration
 test-unit:
 	@echo "=== $(PROJECT_NAME) === [ unit-test        ]: running unit tests..."
 	@gocov test $(GO_PKGS) | gocov-xml > coverage.xml
@@ -57,10 +58,10 @@ bin:
 
 test-security: bin deps
 	@echo "=== $(PROJECT_NAME) === [ security-test        ]: running security tests..."
-	@wget https://github.com/snyk/snyk/releases/download/$(SNYK_VERSION)/snyk-linux -O $(BIN_DIR)/snyk-linux
+	@wget https://github.com/snyk/snyk/releases/download/$(SNYK_VERSION)/$(SNYK_BIN) -O $(BIN_DIR)/$(SNYK_BIN)
 	@chmod +x $(BIN_DIR)/snyk-linux
-	@$(BIN_DIR)/snyk-linux auth $(SNYK_TOKEN)
-	@$(BIN_DIR)/snyk-linux test
+	@$(BIN_DIR)/$(SNYK_BIN) auth $(SNYK_TOKEN)
+	@$(BIN_DIR)/$(SNYK_BIN) test
 
 lint: deps
 	@echo "=== $(PROJECT_NAME) === [ lint             ]: Validating source code running $(GOLINTER)..."


### PR DESCRIPTION
Remove "test-security" goal from the "test" goal.
Test security is only working in Linux for the moment and would fail in other environments