### PR TITLE
fix(perfMetricFile): added default value for argument

### DIFF
--- a/cmd/nri-vsphere/nri-vsphere.go
+++ b/cmd/nri-vsphere/nri-vsphere.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -99,11 +100,15 @@ func checkAndSanitizeConfig(config *load.Config) {
 		config.Logrus.Fatal("missing argument `pass`, please check if password has been supplied")
 	}
 
-	if config.Args.EnableVspherePerfMetrics && config.Args.PerfMetricFile ==""{
+	if config.Args.EnableVspherePerfMetrics && config.Args.PerfMetricFile == "" {
+		var err error
 		if runtime.GOOS == "windows" {
-			config.Args.PerfMetricFile = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\vsphere-performance.metrics"
+			config.Args.PerfMetricFile, err = filepath.Abs(load.WindowsPerfMetricFile)
 		} else {
-			config.Args.PerfMetricFile = "/etc/newrelic-infra/integrations.d/vsphere-performance.metrics"
+			config.Args.PerfMetricFile, err = filepath.Abs(load.LinuxDefaultPerfMetricFile)
+		}
+		if err != nil {
+			config.Logrus.Fatal("error while setting default path for performance metrics configuration file")
 		}
 	}
 

--- a/cmd/nri-vsphere/nri-vsphere.go
+++ b/cmd/nri-vsphere/nri-vsphere.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -96,6 +97,14 @@ func checkAndSanitizeConfig(config *load.Config) {
 	}
 	if config.Args.Pass == "" {
 		config.Logrus.Fatal("missing argument `pass`, please check if password has been supplied")
+	}
+
+	if config.Args.EnableVspherePerfMetrics && config.Args.PerfMetricFile ==""{
+		if runtime.GOOS == "windows" {
+			config.Args.PerfMetricFile = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\vsphere-performance.metrics"
+		} else {
+			config.Args.PerfMetricFile = "/etc/newrelic-infra/integrations.d/vsphere-performance.metrics"
+		}
 	}
 
 	config.Args.DatacenterLocation = strings.ToLower(config.Args.DatacenterLocation)

--- a/internal/load/load.go
+++ b/internal/load/load.go
@@ -78,3 +78,8 @@ func NewConfig(buildVersion string) *Config {
 		TagsByID:             make(map[string]Tag),
 	}
 }
+
+const (
+	WindowsPerfMetricFile      = "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d\\vsphere-performance.metrics"
+	LinuxDefaultPerfMetricFile = "/etc/newrelic-infra/integrations.d/vsphere-performance.metrics"
+)

--- a/internal/performance/performance.go
+++ b/internal/performance/performance.go
@@ -71,7 +71,7 @@ func NewPerfCollector(client *govmomi.Client, logger *logrus.Logger, perfMetricF
 	}
 	err = perfCollector.parseConfigFile(perfMetricFile)
 	if err != nil {
-		logger.WithError(err).Errorf("failed to fetch data from config file")
+		logger.WithError(err).Errorf("failed to fetch data from performance config file")
 		return nil, err
 	}
 

--- a/internal/performance/performance.go
+++ b/internal/performance/performance.go
@@ -71,7 +71,7 @@ func NewPerfCollector(client *govmomi.Client, logger *logrus.Logger, perfMetricF
 	}
 	err = perfCollector.parseConfigFile(perfMetricFile)
 	if err != nil {
-		logger.WithError(err).Errorf("failed to fetch data from performance config file")
+		logger.WithError(err).WithField("file", perfMetricFile).Errorf("failed to fetch data from performance config file")
 		return nil, err
 	}
 


### PR DESCRIPTION
#### Description of the changes

When enabling perf metrics the user had to add a value for the filepath. Since usually it will not change I added a default value. 

The if-else is necessary since the path is different in Windows

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [x] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge