### PR TITLE
feat(vms): add ip addresses attribute

### DIFF
--- a/internal/model/datacenter.go
+++ b/internal/model/datacenter.go
@@ -68,7 +68,8 @@ func (dc *Datacenter) FindHost(computeResourceReference mor) *mo.HostSystem {
 // GetResourcePool returns the name of the Resource Pool if is not the default
 func (dc *Datacenter) GetResourcePool(resourcePoolReference mor) (*mo.ResourcePool, bool) {
 	if !dc.IsDefaultResourcePool(resourcePoolReference) {
-		return dc.ResourcePools[resourcePoolReference], true
+		rp, ok := dc.ResourcePools[resourcePoolReference]
+		return rp, ok
 	}
 	return nil, false
 }

--- a/internal/process/hosts.go
+++ b/internal/process/hosts.go
@@ -22,6 +22,7 @@ func createHostSamples(config *config.Config) {
 			}
 
 			if host.Summary.Hardware == nil {
+				config.Logrus.WithField("hostMOR", host.Self.String()).Debug("host.Summary.Hardware is nil for this host")
 				continue
 			}
 			// bios uuid identifies the host unequivocally and is available from vcenter/host api

--- a/internal/process/vms.go
+++ b/internal/process/vms.go
@@ -171,6 +171,23 @@ func createVirtualMachineSamples(config *config.Config) {
 			// network
 			if vm.Guest != nil {
 				checkError(config.Logrus, ms.SetMetric("ipAddress", vm.Guest.IpAddress, metric.ATTRIBUTE))
+				var ipAddresses strings.Builder
+				for _, nic := range vm.Guest.Net {
+					// available in api v5
+					if nic.IpConfig != nil {
+						for _, addr := range nic.IpConfig.IpAddress {
+							ipAddresses.WriteString(addr.IpAddress)
+							ipAddresses.WriteRune('|')
+						}
+					} else {
+						for _, ip := range nic.IpAddress {
+							ipAddresses.WriteString(ip)
+							ipAddresses.WriteRune('|')
+						}
+					}
+				}
+				// it might be empty but we still add the attribute for consistency
+				checkError(config.Logrus, ms.SetMetric("ipAddresses", ipAddresses.String(), metric.ATTRIBUTE))
 			}
 
 			// vm state

--- a/internal/process/vms.go
+++ b/internal/process/vms.go
@@ -25,21 +25,25 @@ func createVirtualMachineSamples(config *config.Config) {
 			// information would be unavailable if the server is unable to access the virtual machine files on disk,
 			// and is often also unavailable during the initial phases of virtual machine creation.
 			if vm.Config == nil {
+				config.Logrus.WithField("vmMOR", vm.Self.String()).Debug("vm.Config is nil for this vm")
 				continue
 			}
 
 			// resourcePool Returns null if the virtual machine is a template or the session has no access to the resource pool.
 			if vm.ResourcePool == nil {
+				config.Logrus.WithField("vmName", vm.Config.Name).Debug("vm.ResourcePool is nil for this vm")
 				continue
 			}
 
 			// This property is null if the virtual machine is not running and is not assigned to run on a particular host.
 			if vm.Summary.Runtime.Host == nil {
+				config.Logrus.WithField("vmName", vm.Config.Name).Debug("vm.Summary.Runtime.Host is nil for this vm")
 				continue
 			}
 
 			// we need the host and it's parent
 			if h, ok := dc.Hosts[vm.Summary.Runtime.Host.Reference()]; !ok || ok && h.Parent == nil {
+				config.Logrus.WithField("vmName", vm.Config.Name).Debug("host not found for this vm")
 				continue
 			}
 
@@ -186,8 +190,9 @@ func createVirtualMachineSamples(config *config.Config) {
 						}
 					}
 				}
+				ipAddressesTrimmed := strings.TrimSuffix(ipAddresses.String(), "|")
 				// it might be empty but we still add the attribute for consistency
-				checkError(config.Logrus, ms.SetMetric("ipAddresses", ipAddresses.String(), metric.ATTRIBUTE))
+				checkError(config.Logrus, ms.SetMetric("ipAddresses", ipAddressesTrimmed, metric.ATTRIBUTE))
 			}
 
 			// vm state

--- a/internal/process/vms_test.go
+++ b/internal/process/vms_test.go
@@ -1,0 +1,56 @@
+package process
+
+import (
+	"context"
+	"github.com/newrelic/infra-integrations-sdk/integration"
+	"github.com/newrelic/nri-vsphere/internal/client"
+	"github.com/newrelic/nri-vsphere/internal/collect"
+	"github.com/newrelic/nri-vsphere/internal/config"
+	"github.com/newrelic/nri-vsphere/internal/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"testing"
+)
+
+func Test_createVirtualMachineSamples_HasIpAddresses(t *testing.T) {
+	simulator.Run(func(ctx context.Context, vc *vim25.Client) error {
+		vmClient, err := client.New(vc.URL().String(), "user", "pass", false)
+		assert.NoError(t, err)
+		vm := view.NewManager(vc)
+		assert.NotNil(t, vm)
+		// given
+		cfg := &config.Config{VMWareClient: vmClient, ViewManager: vm, Logrus: logrus.StandardLogger()}
+		cfg.Integration, _ = integration.New("test", "dev")
+		cfg.Datacenters = append(cfg.Datacenters, getDatacenter(ctx, vm))
+
+		// when
+		// we need the host to create the vms
+		collect.Hosts(cfg)
+		collect.VirtualMachines(cfg)
+
+		createVirtualMachineSamples(cfg)
+		// then
+		assert.True(t, len(cfg.Datacenters[0].VirtualMachines) > 0)
+		for _, e := range cfg.Integration.Entities {
+			for _, ms := range e.Metrics {
+				// we just chek the presence because it might have no 'extra' ip addresses but we still add the attribute
+				assert.Contains(t, ms.Metrics, "ipAddresses")
+			}
+		}
+		return nil
+	})
+}
+
+func getDatacenter(ctx context.Context, vm *view.Manager) *model.Datacenter {
+	cv, err := vm.CreateContainerView(ctx, vm.Client().ServiceContent.RootFolder, []string{"Datacenter"}, false)
+	if err != nil {
+		logrus.Fatal("failed to get container view")
+	}
+	var datacenters []mo.Datacenter
+	_ = cv.Retrieve(ctx, []string{"Datacenter"}, []string{"name"}, &datacenters)
+	return model.NewDatacenter(&datacenters[0])
+}


### PR DESCRIPTION
Adds all ip addresses we can find for the vm in the `ipAdresses`attribute, except the primary one which is already added to the `ipAddress` attribute.
The ip addresses are added as a string separated by pipes, '|'. Example: '127.0.0.1|10.0.0.01|10.100.1.1'