### PR TITLE
fix(perMetrics): collect all instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Use the flag `--perf_level` to select which level of **performance metrics** you
 
 Please note that the more performance metrics you enable the more load you add to your environment.
 
+Notice that the integration fetches multiple values for a single performance metrics related to different "instances" 
+belonging to a single object, but only the average value is stored.
+
+For example, the counter `cpu.usage.average` returns multiple values: one for each CPU core of an host.
+The integration uses these values to compute the average, that is then included in the `VSphereHostSample` sample.
+
 ## Building
 
 If you have downloaded the source code and installed the Go toolchain, you can build and run the vSphere integration locally.

--- a/configs/vsphere-performance.metrics
+++ b/configs/vsphere-performance.metrics
@@ -12,6 +12,12 @@
 # For more information on performance metrics, see the official VMware docs:
 # https://docs.vmware.com/en/VMware-vSphere/6.7/vsphere-esxi-vcenter-server-67-monitoring-performance-guide.pdf
 # https://vdc-repo.vmware.com/vmwb-repository/dcr-public/790263bc-bd30-48f1-af12-ed36055d718b/e5f17bfc-ecba-40bf-a04f-376bbb11e811/vim.PerformanceManager.html
+#
+# Notice that the integration fetches multiple values for a single performance metrics related to different "instances"
+# belonging to a single object, but only the average value is stored.
+# For example, the counter `cpu.usage.average` returns multiple values: one for each CPU core of an host.
+# The integration uses these values to compute the average, that is then included in the `VSphereHostSample` sample.
+#
 
 host:
   level_1:

--- a/internal/performance/performance.go
+++ b/internal/performance/performance.go
@@ -115,7 +115,7 @@ func (c *PerfCollector) Collect(mos []types.ManagedObjectReference, metrics []ty
 				//The query return a generic inside a generic, however there is only one type we ca cast to:
 				// More info: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/790263bc-bd30-48f1-af12-ed36055d718b/e5f17bfc-ecba-40bf-a04f-376bbb11e811/vim.PerformanceManager.html#queryStats
 				metricsValues, ok := returnVal.(*types.PerfEntityMetric)
-				if !ok || metricsValues == nil {
+				if !ok {
 					continue
 				}
 				c.processEntityMetrics(metricsValues, perfMetricsByRef)
@@ -134,6 +134,10 @@ func (c *PerfCollector) processEntityMetrics(metricsValues *types.PerfEntityMetr
 
 	// If for the same metrics multiple instances are returned we perform the average of the values
 	accumulateMetrics := map[string]*Accumulator{}
+	if metricsValues == nil {
+		return
+	}
+
 	for _, metricValue := range metricsValues.Value {
 		metricValueSeries, ok2 := metricValue.(*types.PerfMetricIntSeries)
 		if !ok2 || metricValueSeries == nil {


### PR DESCRIPTION
#### Description of the changes

Fix https://github.com/newrelic/nri-vsphere/issues/80

We were not specifying any instance name when retrieving data, this cas causing the vcenter not to return counter being connected to entities.

This PR can increase the load but will retrieve all the counters users asked for.

Granularity: if multiple counters are linked to a single object we need to perform an average in order to attach a single value to the sample we send to the backend. In some scenario this granularity could be not enough


Comparing host entity before and after the fix LEVEL 1 perf metrics:

```
NEW SAMPLE
      "metrics": [
        {
[...]
          "perf.cpu.ready.summation": 16,
          "perf.cpu.usage.average": 47,
          "perf.cpu.usagemhz.average": 76,
          "perf.datastore.datastoreIops.average": 0,
          "perf.datastore.datastoreMaxQueueDepth.latest": 1024,
          "perf.datastore.datastoreReadIops.latest": 0,
          "perf.datastore.datastoreReadOIO.latest": 0,
          "perf.datastore.datastoreVMObservedLatency.latest": 0,
          "perf.datastore.datastoreWriteIops.latest": 0,
          "perf.datastore.datastoreWriteOIO.latest": 0,
          "perf.datastore.numberReadAveraged.average": 0,
          "perf.datastore.numberWriteAveraged.average": 0,
          "perf.datastore.siocActiveTimePercentage.average": 0,
          "perf.datastore.sizeNormalizedDatastoreLatency.average": 0,
          "perf.datastore.totalReadLatency.average": 0,
          "perf.datastore.totalWriteLatency.average": 0,
          "perf.disk.deviceLatency.average": 0,
          "perf.disk.maxQueueDepth.average": 1024,
          "perf.disk.maxTotalLatency.latest": 0,
          "perf.disk.numberReadAveraged.average": 0,
          "perf.disk.numberWriteAveraged.average": 0,
          "perf.disk.usage.average": 41,
          "perf.mem.consumed.average": 1445168,
          "perf.mem.overhead.average": 0,
          "perf.mem.swapinRate.average": 0,
          "perf.mem.swapoutRate.average": 0,
          "perf.mem.usage.average": 3449,
          "perf.mem.vmmemctl.average": 0,
          "perf.net.usage.average": 195,
          "perf.sys.uptime.latest": 17035943,
[...]
        }
]

OLD SAMPLE

"metrics": [
        {
[...]
          "perf.cpu.ready.summation": 6,
          "perf.cpu.usage.average": 47,
          "perf.cpu.usagemhz.average": 75,
          "perf.disk.maxTotalLatency.latest": 0,
          "perf.disk.usage.average": 53,
          "perf.mem.consumed.average": 1445464,
          "perf.mem.overhead.average": 0,
          "perf.mem.swapinRate.average": 0,
          "perf.mem.swapoutRate.average": 0,
          "perf.mem.usage.average": 3450,
          "perf.mem.vmmemctl.average": 0,
          "perf.net.usage.average": 197,
          "perf.sys.uptime.latest": 17036023,
[...]
        }
```

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 
- [x] add a "ready for review" label. Only PRs with this label will be reviewed.

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge