### PR TITLE
[Do NOT merge] Test public pr mods

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -12,7 +12,7 @@ env:
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
   ORIGINAL_REPO_NAME: "newrelic/nri-vsphere"
   GO_VERSION: '1.15.7'
-
+  DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
 jobs:
   validate:
     name: Validate code via linters
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub
+        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
@@ -35,11 +36,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub
+        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Scan code for vulnerabilities
+        if: ${{env.SNYK_TOKEN}}
         run: make ci/snyk-test
 
   test-nix:
@@ -48,6 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub
+        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
@@ -105,6 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub
+        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}


### PR DESCRIPTION
PR to test the logic we are going to implement to discard docker login and snyk execution on external PR (because the secrets are not available)

Regarding docker rate limit , it looks like there is no limit for GHA from [this communication](https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495). On the other hand the Docker hub [docs](https://docs.docker.com/docker-hub/download-rate-limit/#github-actions) recommend the use of login on GHA, so we are keeping it for auth users.

Snyk check will be executed upon the merge of the PR and before release, so just the early detection is lost.