### PR TITLE
chore(ci): fix rpm name to be coherent with publish schema

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -59,9 +59,9 @@ nfpms:
 
     overrides:
       rpm:
-        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
+        file_name_template: "{{ .ProjectName }}-{{ .Version }}-1.{{ .Arch }}"
         replacements:
-          amd64: 1.x86_64
+          amd64: x86_64
 
     formats:
       - deb


### PR DESCRIPTION
Fix rpm name to match the ohi scheme from the newrelic-publish-action. https://github.com/newrelic/infrastructure-publish-action/blob/main/schemas/ohi.yml