### PR TITLE
chore(ci): bump github cli

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15.7
 
-ARG GH_VERSION='1.4.0'
+ARG GH_VERSION='2.4.0'
 
 RUN apt-get update \
     && apt-get -y install \


### PR DESCRIPTION
Bumping version of gh cli used to push the packages into the GH release.