### PR TITLE
Fix/performance metrics comp

### DIFF
--- a/internal/process/datacenter.go
+++ b/internal/process/datacenter.go
@@ -86,6 +86,7 @@ func createDatacenterSamples(config *config.Config) {
 			checkError(config.Logrus, ms.SetMetric("mem.usagePercentage", memoryPercentHost, metric.GAUGE))
 		}
 
+		checkError(config.Logrus, ms.SetMetric("datacenterName", datacenterName, metric.ATTRIBUTE))
 		checkError(config.Logrus, ms.SetMetric("mem.size", totalMemoryHost, metric.GAUGE))
 		checkError(config.Logrus, ms.SetMetric("mem.usage", totalMemoryUsedHost, metric.GAUGE))
 		checkError(config.Logrus, ms.SetMetric("cpu.cores", totalCpuHost, metric.GAUGE))


### PR DESCRIPTION
#### Description of the changes

Fix https://github.com/newrelic/nri-vsphere/issues/83
Fix https://github.com/newrelic/nri-vsphere/issues/102

The metric returned have a field indicating the 'instance' it refers to. However, the vCenter could mix standard values and aggregated values. 
We give priority to the raw values and fall back to 'instanceless' values in case no raw data has been received. InstanceLess metrics are aggregated already or referring to memory

[vmWare Docs](https://vdc-download.vmware.com/vmwb-repository/dcr-public/6b586ed2-655c-49d9-9029-bc416323cb22/fa0b429a-a695-4c11-b7d2-2cbc284049dc/doc/vim.PerformanceManager.MetricId.html
)

> Instance:
 An identifier that is derived from configuration names for the device associated with the metric. It identifies the instance of the metric with its source. This property may be empty.
> -  For memory and aggregated statistics, this property is empty.
> -  For host and virtual machine devices, this property contains the name of the device, such as the name of the host-bus   adapter or the name of the virtual Ethernet adapter. For example, “mpx.vmhba33:C0:T0:L0” or “vmnic0:”
> -  For a CPU, this property identifies the numeric position within the CPU core, such as 0, 1, 2, 3.

