### PR TITLE
fix: resolve CodeQL go/incorrect-integer-conversion

### DIFF
--- a/internal/events/eventDispacher.go
+++ b/internal/events/eventDispacher.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -122,6 +123,11 @@ func (ed *EventDispacher) CollectEvents(eventsPageSize string) {
 	pageSize, err := strconv.Atoi(eventsPageSize)
 	if err != nil {
 		ed.log.WithError(err).Error("error while parsing EventsPageSize, using default value")
+		pageSize = pageSizeDefault
+	}
+
+	if pageSize <= 0 || pageSize > math.MaxInt32 {
+		ed.log.Warnf("EventsPageSize %d out of valid range, using default", pageSize)
 		pageSize = pageSizeDefault
 	}
 

--- a/internal/process/hosts.go
+++ b/internal/process/hosts.go
@@ -110,7 +110,7 @@ func createHostSamples(config *config.Config) {
 			memoryUsed := host.Summary.QuickStats.OverallMemoryUsage
 			checkError(config.Logrus, ms.SetMetric("mem.usage", memoryUsed, metric.GAUGE))
 
-			memoryFree := int32(memoryTotal) - memoryUsed
+			memoryFree := memoryTotal - int64(memoryUsed)
 			checkError(config.Logrus, ms.SetMetric("mem.free", memoryFree, metric.GAUGE))
 
 			// cpu


### PR DESCRIPTION
## Summary
- Fix unsafe `int64` → `int32` narrowing in `hosts.go` memory calculation that could overflow for hosts with >2GB RAM
- Add bounds validation for `pageSize` before `int32` conversion in `eventDispacher.go`

## Root Cause
CodeQL flagged two instances of `go/incorrect-integer-conversion`:
1. `int32(memoryTotal)` where `memoryTotal` is `int64` — hosts with >2GB RAM would overflow
2. `int32(pageSize)` where `pageSize` comes from `strconv.Atoi()` with no range check

## Test plan
- [ ] Verify build passes (`go build ./...`)
- [ ] Verify existing tests pass (`go test ./...`)
- [ ] Confirm CodeQL alert is resolved after merge

Resolves: [NR-560201](https://new-relic.atlassian.net/browse/NR-560201)

[NR-560201]: https://new-relic.atlassian.net/browse/NR-560201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ